### PR TITLE
Add VMware example for vTPM provision policy (New-ProvScheme/Set-ProvScheme)

### DIFF
--- a/VMware/ProvScheme/README.md
+++ b/VMware/ProvScheme/README.md
@@ -23,3 +23,4 @@ The following folders explain the VMware features for **ProvScheme**:
 * [Write-Back Cache](./Write-Back%20Cache/): Descriptions for utilizing Write-Back Cache.
 * [Data Disk](./Data%20Disk/): Descriptions for utilizing Data Disk.
 * [Folder Id](./Folder%20ID/): Descriptions for updating Folder Id.
+* [vTPM Provision Policy](./vTPM%20Provision%20Policy/): Descriptions for controlling the vTPM provision policy (None, Clone, Clean).

--- a/VMware/ProvScheme/vTPM Provision Policy/Create-ProvScheme-VtpmProvisionPolicy.ps1
+++ b/VMware/ProvScheme/vTPM Provision Policy/Create-ProvScheme-VtpmProvisionPolicy.ps1
@@ -1,0 +1,64 @@
+﻿<#
+.SYNOPSIS
+    Creates a ProvScheme that sets the vTPM provision policy.
+.DESCRIPTION
+    Create-ProvScheme-VtpmProvisionPolicy.ps1 creates a VMware ProvScheme and uses the
+    VtpmProvisionPolicy parameter to control how the vTPM device of each provisioned VM is created.
+
+    The vTPM provision policy only takes effect when the machine profile contains a vTPM, so this
+    example provisions from a machine profile template (-MachineProfile).
+
+    Accepted values for -VtpmProvisionPolicy:
+      - None  : The default, used when the parameter is omitted. No explicit policy; the legacy
+                behavior is used. There is no need to pass None explicitly.
+      - Clone : Clone the vTPM content from the source (machine profile). All provisioned VMs share
+                the same vTPM content (for example, to carry over TPM-protected keys such as BitLocker).
+      - Clean : Create a brand new (blank) vTPM device for each provisioned VM, so every machine gets
+                a unique vTPM.
+
+    The original version of this script is compatible with Citrix Virtual Apps and Desktops 7 2511.
+.INPUTS
+    N/A
+.OUTPUTS
+    A New Provisioning Scheme Object
+.NOTES
+    Version      : 1.0.0
+    Author       : Citrix Systems, Inc.
+.EXAMPLE
+    .\Create-ProvScheme-VtpmProvisionPolicy.ps1
+#>
+
+# /*************************************************************************
+# * Copyright © 2026. Cloud Software Group, Inc. All Rights Reserved.
+# * This file is subject to the license terms contained
+# * in the license file that is distributed with this file.
+# *************************************************************************/
+
+# Enable Citrix PowerShell Cmdlets
+Add-PSSnapin citrix*
+
+# Example Configuration for New-ProvScheme.
+$ProvisioningSchemeName  = "MyMachineCatalog"
+$IdentityPoolName        = "MyMachineCatalog"
+$HostingUnitName         = "MyHostingUnit"
+$MasterImageVM           = "XDHyp:\HostingUnits\MyHostingUnit\MyVM.vm\MySnapshot.snapshot"
+$MachineProfile          = "XDHyp:\HostingUnits\MyHostingUnit\MyVM-Template.template"
+$NetworkMapping          = @{"0"="XDHyp:\HostingUnits\MyHostingUnit\MyNetwork.network"}
+
+# The vTPM provision policy. Allowed values: Clone or Clean.
+# Omit -VtpmProvisionPolicy entirely to use the default (None).
+$VtpmProvisionPolicy     = "Clone"
+
+# Create a Provisioning Scheme.
+# -MachineProfile is required because the vTPM provision policy only applies when the
+#  machine profile contains a vTPM. Hardware properties such as CPU count and memory are
+#  captured from the machine profile, so they are not specified explicitly here.
+New-ProvScheme `
+    -ProvisioningSchemeName $ProvisioningSchemeName `
+    -IdentityPoolName $IdentityPoolName `
+    -HostingUnitName $HostingUnitName `
+    -MasterImageVM $MasterImageVM `
+    -MachineProfile $MachineProfile `
+    -NetworkMapping $NetworkMapping `
+    -CleanOnBoot:$false `
+    -VtpmProvisionPolicy $VtpmProvisionPolicy

--- a/VMware/ProvScheme/vTPM Provision Policy/New-ProvSchemeVersion-VtpmProvisionPolicy.ps1
+++ b/VMware/ProvScheme/vTPM Provision Policy/New-ProvSchemeVersion-VtpmProvisionPolicy.ps1
@@ -1,0 +1,68 @@
+﻿<#
+.SYNOPSIS
+    Creates a new configuration version of a provisioning scheme that sets the vTPM provision policy.
+    Applicable for Citrix DaaS and on-prem.
+.DESCRIPTION
+    New-ProvSchemeVersion-VtpmProvisionPolicy.ps1 creates a new configuration version for an existing
+    VMware MCS provisioning scheme and sets the vTPM provision policy on that version. New machines
+    created from this version use the specified policy.
+
+    Note: New-ProvSchemeVersion is an experimental command and part of the image-decouple workflow.
+
+    Accepted values for -VtpmProvisionPolicy:
+      - Clone : Clone the vTPM content from the source (machine profile).
+      - Clean : Create a brand new (blank) vTPM device for each provisioned VM.
+      - None  : The default. There is no need to pass it explicitly.
+
+    The vTPM provision policy only takes effect when the machine profile contains a vTPM.
+
+    The original version of this script is compatible with Citrix Virtual Apps and Desktops 7 2511.
+.INPUTS
+    1. ProvisioningSchemeName: Name of the provisioning scheme to create a new version for.
+    2. VtpmProvisionPolicy: The vTPM provision policy (Clone or Clean).
+    3. MachineProfile (optional): Path to a machine profile template, if the new version should set one.
+.OUTPUTS
+    A New Provisioning Scheme Version Object
+.NOTES
+    Version      : 1.0.0
+    Author       : Citrix Systems, Inc.
+.EXAMPLE
+    .\New-ProvSchemeVersion-VtpmProvisionPolicy.ps1 `
+        -ProvisioningSchemeName "MyCatalog" `
+        -VtpmProvisionPolicy "Clone"
+#>
+
+# /*************************************************************************
+# * Copyright © 2026. Cloud Software Group, Inc. All Rights Reserved.
+# * This file is subject to the license terms contained
+# * in the license file that is distributed with this file.
+# *************************************************************************/
+
+##########################
+# Step 0: Set parameters #
+##########################
+param(
+    [Parameter(Mandatory = $true)]
+    [string] $ProvisioningSchemeName,
+
+    [Parameter(Mandatory = $true)]
+    [ValidateSet("None", "Clone", "Clean")]
+    [string] $VtpmProvisionPolicy,
+
+    # Optional. Provide a machine profile if the new version should set or change it.
+    [string] $MachineProfile
+)
+
+# Enable Citrix PowerShell Cmdlets
+Add-PSSnapin citrix*
+
+###############################################################
+# Step 1: Create a new scheme version with the vTPM policy.   #
+###############################################################
+
+if ([string]::IsNullOrWhiteSpace($MachineProfile)) {
+    New-ProvSchemeVersion -ProvisioningSchemeName $ProvisioningSchemeName -VtpmProvisionPolicy $VtpmProvisionPolicy
+}
+else {
+    New-ProvSchemeVersion -ProvisioningSchemeName $ProvisioningSchemeName -VtpmProvisionPolicy $VtpmProvisionPolicy -MachineProfile $MachineProfile
+}

--- a/VMware/ProvScheme/vTPM Provision Policy/New-ProvVMConfiguration-VtpmProvisionPolicy.ps1
+++ b/VMware/ProvScheme/vTPM Provision Policy/New-ProvVMConfiguration-VtpmProvisionPolicy.ps1
@@ -1,0 +1,72 @@
+﻿<#
+.SYNOPSIS
+    Creates a new configuration for a provisioned virtual machine that sets the vTPM provision policy.
+    Applicable for Citrix DaaS and on-prem.
+.DESCRIPTION
+    New-ProvVMConfiguration-VtpmProvisionPolicy.ps1 creates a new configuration for a specific
+    provisioned VM in a VMware MCS catalog and sets the vTPM provision policy on that configuration.
+
+    Note: New-ProvVMConfiguration is an experimental command and part of the image-decouple workflow.
+
+    Accepted values for -VtpmProvisionPolicy:
+      - Clone : Clone the vTPM content from the source (machine profile).
+      - Clean : Create a brand new (blank) vTPM device for the VM.
+      - None  : The default. There is no need to pass it explicitly.
+
+    The vTPM provision policy only takes effect when the machine profile contains a vTPM.
+
+    The original version of this script is compatible with Citrix Virtual Apps and Desktops 7 2511.
+.INPUTS
+    1. ProvisioningSchemeName: Name of the provisioning scheme the VM belongs to.
+    2. VMName: Name of the provisioned virtual machine.
+    3. VtpmProvisionPolicy: The vTPM provision policy (Clone or Clean).
+    4. MachineProfile (optional): Path to a machine profile template, if the configuration needs one.
+.OUTPUTS
+    A New Provisioned VM Configuration Object
+.NOTES
+    Version      : 1.0.0
+    Author       : Citrix Systems, Inc.
+.EXAMPLE
+    .\New-ProvVMConfiguration-VtpmProvisionPolicy.ps1 `
+        -ProvisioningSchemeName "MyCatalog" `
+        -VMName "MyCatalog-VM-01" `
+        -VtpmProvisionPolicy "Clean"
+#>
+
+# /*************************************************************************
+# * Copyright © 2026. Cloud Software Group, Inc. All Rights Reserved.
+# * This file is subject to the license terms contained
+# * in the license file that is distributed with this file.
+# *************************************************************************/
+
+##########################
+# Step 0: Set parameters #
+##########################
+param(
+    [Parameter(Mandatory = $true)]
+    [string] $ProvisioningSchemeName,
+
+    [Parameter(Mandatory = $true)]
+    [string] $VMName,
+
+    [Parameter(Mandatory = $true)]
+    [ValidateSet("None", "Clone", "Clean")]
+    [string] $VtpmProvisionPolicy,
+
+    # Optional. Provide a machine profile if the configuration should set or change it.
+    [string] $MachineProfile
+)
+
+# Enable Citrix PowerShell Cmdlets
+Add-PSSnapin citrix*
+
+##################################################################
+# Step 1: Create a new VM configuration with the vTPM policy.    #
+##################################################################
+
+if ([string]::IsNullOrWhiteSpace($MachineProfile)) {
+    New-ProvVMConfiguration -ProvisioningSchemeName $ProvisioningSchemeName -VMName $VMName -VtpmProvisionPolicy $VtpmProvisionPolicy
+}
+else {
+    New-ProvVMConfiguration -ProvisioningSchemeName $ProvisioningSchemeName -VMName $VMName -VtpmProvisionPolicy $VtpmProvisionPolicy -MachineProfile $MachineProfile
+}

--- a/VMware/ProvScheme/vTPM Provision Policy/README.md
+++ b/VMware/ProvScheme/vTPM Provision Policy/README.md
@@ -1,0 +1,95 @@
+﻿# Using the vTPM Provision Policy of VMware for Machine Catalog Creation
+
+This page describes the use of the **vTPM provision policy** when creating or updating a ProvScheme on VMware in Citrix Virtual Apps and Desktops (CVAD) / Citrix DaaS. The scripts in this folder show example usage of the `VtpmProvisionPolicy` parameter on `New-ProvScheme`, `Set-ProvScheme`, `Set-ProvVM`, `New-ProvSchemeVersion`, and `New-ProvVMConfiguration`.
+
+## 1. Understanding the vTPM Provision Policy
+
+A virtual Trusted Platform Module (vTPM) provides hardware-based, security-related functions to a VM, such as storing the keys used by BitLocker. On VMware, the vTPM device is attached to the VM/template, and its content cannot be imported or exported separately — it can only be cloned from one VM/template to another.
+
+Historically the behavior of the vTPM on provisioned VMs depended on the source:
+
+- A VMware **machine profile** template **copies** the vTPM content, so all provisioned VMs end up with the same vTPM content.
+- A **master image** creates a **new** vTPM for each VM.
+
+This was inconsistent and, for some workloads, incorrect. The `VtpmProvisionPolicy` parameter lets the administrator explicitly choose the behavior:
+
+| Value | Behavior |
+|-------|----------|
+| `None` | **The default**, used when the parameter is omitted. No explicit policy is applied; the legacy behavior is used. There is no need to pass `None` explicitly — simply leave the parameter out. |
+| `Clone` | The vTPM content is cloned from the source (machine profile). All provisioned VMs share the same vTPM content. Use this when machines must carry over TPM-protected secrets (for example, BitLocker keys). |
+| `Clean` | A brand new (blank) vTPM device is created for each provisioned VM, so every machine has a unique vTPM. Use this to avoid sharing the same vTPM content across machines. |
+
+> **Notes:**
+> - This property is applicable only to MCS provisioning schemes.
+> - `None` is the default. You do not pass it explicitly; omitting `-VtpmProvisionPolicy` on `New-ProvScheme` creates the scheme with `None`, and omitting it on `Set-ProvScheme` leaves the current policy unchanged.
+> - The value does **not** take effect when the machine profile does not contain a vTPM. For that reason the create example provisions from a machine profile template (`-MachineProfile`).
+> - When `Set-ProvScheme` is used to change the policy, the updated value applies to **new** machines added after the operation, not to existing machines.
+
+## 2. How to use the vTPM Provision Policy
+
+### Create a Provisioning Scheme
+
+When using `New-ProvScheme`, specify the `VtpmProvisionPolicy` parameter together with a machine profile that contains a vTPM (other standard `New-ProvScheme` parameters are included so the snippet runs as-is):
+
+```powershell
+New-ProvScheme `
+    -ProvisioningSchemeName "MyMachineCatalog" `
+    -IdentityPoolName "MyMachineCatalog" `
+    -HostingUnitName "MyHostingUnit" `
+    -MasterImageVM "XDHyp:\HostingUnits\MyHostingUnit\MyVM.vm\MySnapshot.snapshot" `
+    -MachineProfile "XDHyp:\HostingUnits\MyHostingUnit\MyVM-Template.template" `
+    -NetworkMapping @{"0"="XDHyp:\HostingUnits\MyHostingUnit\MyNetwork.network"} `
+    -CleanOnBoot:$false `
+    -VtpmProvisionPolicy "Clone"
+```
+
+### Update an existing Provisioning Scheme
+
+Yes — you can change the policy on a previously created catalog using `Set-ProvScheme`:
+
+```powershell
+Set-ProvScheme -ProvisioningSchemeName "MyMachineCatalog" -VtpmProvisionPolicy "Clean"
+```
+
+Setting a non-`None` policy on an existing catalog has the following requirements:
+
+1. **Hypervisor support** — the catalog must be on a hypervisor that supports the vTPM provision policy (VMware).
+2. **Machine profile** — the catalog must have a machine profile. If the existing catalog has **no** machine profile, you must supply one in the same call (shown below). The policy only takes effect when that machine profile contains a vTPM.
+
+   ```powershell
+   Set-ProvScheme -ProvisioningSchemeName "MyMachineCatalog" `
+       -VtpmProvisionPolicy "Clone" `
+       -MachineProfile "XDHyp:\HostingUnits\MyHostingUnit\MyVM-Template.template"
+   ```
+3. **Scope of effect** — the updated policy applies to **new** machines added after the operation, not to machines that already exist in the catalog.
+
+**Note**: To keep the policy unchanged, simply omit `-VtpmProvisionPolicy`. Pass `None` only when you explicitly want to reset the catalog to the default behavior.
+
+### Other cmdlets that accept the policy
+
+The `VtpmProvisionPolicy` parameter is also available on the following cmdlets. The same accepted values and machine-profile requirement apply.
+
+```powershell
+# Override the policy for a single provisioned VM
+Set-ProvVM -ProvisioningSchemeName "MyMachineCatalog" -VMName "MyMachineCatalog-VM-01" -VtpmProvisionPolicy "Clean"
+
+# Create a new configuration version of a scheme with the policy (experimental command)
+New-ProvSchemeVersion -ProvisioningSchemeName "MyMachineCatalog" -VtpmProvisionPolicy "Clone"
+
+# Create a new configuration for a provisioned VM with the policy (experimental command)
+New-ProvVMConfiguration -ProvisioningSchemeName "MyMachineCatalog" -VMName "MyMachineCatalog-VM-01" -VtpmProvisionPolicy "Clean"
+```
+
+## 3. Example Full Scripts Utilizing the vTPM Provision Policy
+
+1. [Create a Machine Catalog with a vTPM provision policy (`New-ProvScheme`)](Create-ProvScheme-VtpmProvisionPolicy.ps1)
+2. [Update a Machine Catalog with a vTPM provision policy (`Set-ProvScheme`)](Set-ProvScheme-VtpmProvisionPolicy.ps1)
+3. [Update the vTPM provision policy for a single VM (`Set-ProvVM`)](Set-ProvVM-VtpmProvisionPolicy.ps1)
+4. [Create a new scheme version with a vTPM provision policy (`New-ProvSchemeVersion`)](New-ProvSchemeVersion-VtpmProvisionPolicy.ps1)
+5. [Create a new VM configuration with a vTPM provision policy (`New-ProvVMConfiguration`)](New-ProvVMConfiguration-VtpmProvisionPolicy.ps1)
+
+## 4. Reference Documents
+
+For comprehensive information and further reading, the following resources are recommended. These include CVAD SDK documentation and other relevant references (as applicable):
+
+1. [CVAD SDK - About Machine Profile](https://developer-docs.citrix.com/en-us/citrix-daas-sdk/MachineCreation/about_Prov_MachineProfile.html)

--- a/VMware/ProvScheme/vTPM Provision Policy/Set-ProvScheme-VtpmProvisionPolicy.ps1
+++ b/VMware/ProvScheme/vTPM Provision Policy/Set-ProvScheme-VtpmProvisionPolicy.ps1
@@ -1,0 +1,87 @@
+﻿<#
+.SYNOPSIS
+    Sets or changes the VtpmProvisionPolicy parameter on an existing MCS catalog. The updated policy
+    is applied to new machines added after the operation, not to existing machines. Applicable for
+    Citrix DaaS and on-prem.
+.DESCRIPTION
+    Set-ProvScheme-VtpmProvisionPolicy.ps1 changes the vTPM provision policy on an existing VMware
+    MCS catalog.
+
+    Accepted values for -VtpmProvisionPolicy:
+      - Clone : Clone the vTPM content from the source (machine profile). All provisioned VMs share
+                the same vTPM content (for example, to carry over TPM-protected keys such as BitLocker).
+      - Clean : Create a brand new (blank) vTPM device for each provisioned VM, so every machine gets
+                a unique vTPM.
+      - None  : The default. There is no need to pass it explicitly; omitting the parameter leaves the
+                policy unchanged. Pass None only if you want to reset an existing catalog back to the
+                default behavior.
+
+    Requirements for setting a non-None policy on an existing catalog:
+      1. The hypervisor must support the vTPM provision policy (VMware).
+      2. The catalog must have a machine profile. If the existing catalog has no machine profile,
+         supply one in the same call with -MachineProfile (this script does that when -MachineProfile
+         is provided). The policy only takes effect when that machine profile contains a vTPM.
+      3. The updated policy applies to NEW machines added after this operation, not to existing machines.
+
+    The vTPM provision policy only takes effect when the machine profile contains a vTPM.
+
+    The original version of this script is compatible with Citrix Virtual Apps and Desktops 7 2511.
+.INPUTS
+    1. ProvisioningSchemeName: Name of the provisioning scheme to be updated.
+    2. VtpmProvisionPolicy: The new vTPM provision policy (Clone or Clean; or None to reset).
+    3. MachineProfile (optional): Path to a machine profile template. Required only if the existing
+       catalog does not already have a machine profile.
+.OUTPUTS
+    N/A
+.NOTES
+    Version      : 1.0.0
+    Author       : Citrix Systems, Inc.
+.EXAMPLE
+    # Existing catalog that already uses a machine profile
+    .\Set-ProvScheme-VtpmProvisionPolicy.ps1 `
+        -ProvisioningSchemeName "MyCatalog" `
+        -VtpmProvisionPolicy "Clean"
+.EXAMPLE
+    # Existing catalog that has no machine profile yet
+    .\Set-ProvScheme-VtpmProvisionPolicy.ps1 `
+        -ProvisioningSchemeName "MyCatalog" `
+        -VtpmProvisionPolicy "Clone" `
+        -MachineProfile "XDHyp:\HostingUnits\MyHostingUnit\MyVM-Template.template"
+#>
+
+# /*************************************************************************
+# * Copyright © 2026. Cloud Software Group, Inc. All Rights Reserved.
+# * This file is subject to the license terms contained
+# * in the license file that is distributed with this file.
+# *************************************************************************/
+
+##########################
+# Step 0: Set parameters #
+##########################
+param(
+    [Parameter(Mandatory = $true)]
+    [string] $ProvisioningSchemeName,
+
+    [Parameter(Mandatory = $true)]
+    [ValidateSet("None", "Clone", "Clean")]
+    [string] $VtpmProvisionPolicy,
+
+    # Optional. Only needed when the existing catalog does not already have a machine profile.
+    [string] $MachineProfile
+)
+
+# Enable Citrix PowerShell Cmdlets
+Add-PSSnapin citrix*
+
+############################################################
+# Step 1: Change the Provisioning Scheme VtpmProvisionPolicy #
+############################################################
+
+# The updated policy applies to new machines post operation, not to existing machines.
+if ([string]::IsNullOrWhiteSpace($MachineProfile)) {
+    Set-ProvScheme -ProvisioningSchemeName $ProvisioningSchemeName -VtpmProvisionPolicy $VtpmProvisionPolicy
+}
+else {
+    # Provide a machine profile in the same call when the catalog has none yet.
+    Set-ProvScheme -ProvisioningSchemeName $ProvisioningSchemeName -VtpmProvisionPolicy $VtpmProvisionPolicy -MachineProfile $MachineProfile
+}

--- a/VMware/ProvScheme/vTPM Provision Policy/Set-ProvVM-VtpmProvisionPolicy.ps1
+++ b/VMware/ProvScheme/vTPM Provision Policy/Set-ProvVM-VtpmProvisionPolicy.ps1
@@ -1,0 +1,73 @@
+﻿<#
+.SYNOPSIS
+    Changes the vTPM provision policy for a specific provisioned virtual machine. Applicable for
+    Citrix DaaS and on-prem.
+.DESCRIPTION
+    Set-ProvVM-VtpmProvisionPolicy.ps1 changes the vTPM provision policy on an individual VM in a
+    VMware MCS catalog, overriding the catalog-level policy for that VM. The new policy is applied the
+    next time the VM is (re)created from its configuration; it does not modify an already-provisioned
+    vTPM device.
+
+    Accepted values for -VtpmProvisionPolicy:
+      - Clone : Clone the vTPM content from the source (machine profile).
+      - Clean : Create a brand new (blank) vTPM device for the VM.
+      - None  : The default. There is no need to pass it explicitly; omitting the parameter leaves the
+                policy unchanged. Pass None only to reset the VM back to the default behavior.
+
+    The vTPM provision policy only takes effect when the machine profile contains a vTPM.
+
+    The original version of this script is compatible with Citrix Virtual Apps and Desktops 7 2511.
+.INPUTS
+    1. ProvisioningSchemeName: Name of the provisioning scheme the VM belongs to.
+    2. VMName: Name of the provisioned virtual machine to update.
+    3. VtpmProvisionPolicy: The new vTPM provision policy (Clone or Clean; or None to reset).
+    4. MachineProfile (optional): Path to a machine profile template, if the VM configuration needs one.
+.OUTPUTS
+    N/A
+.NOTES
+    Version      : 1.0.0
+    Author       : Citrix Systems, Inc.
+.EXAMPLE
+    .\Set-ProvVM-VtpmProvisionPolicy.ps1 `
+        -ProvisioningSchemeName "MyCatalog" `
+        -VMName "MyCatalog-VM-01" `
+        -VtpmProvisionPolicy "Clean"
+#>
+
+# /*************************************************************************
+# * Copyright © 2026. Cloud Software Group, Inc. All Rights Reserved.
+# * This file is subject to the license terms contained
+# * in the license file that is distributed with this file.
+# *************************************************************************/
+
+##########################
+# Step 0: Set parameters #
+##########################
+param(
+    [Parameter(Mandatory = $true)]
+    [string] $ProvisioningSchemeName,
+
+    [Parameter(Mandatory = $true)]
+    [string] $VMName,
+
+    [Parameter(Mandatory = $true)]
+    [ValidateSet("None", "Clone", "Clean")]
+    [string] $VtpmProvisionPolicy,
+
+    # Optional. Only needed when the VM configuration must also set a machine profile.
+    [string] $MachineProfile
+)
+
+# Enable Citrix PowerShell Cmdlets
+Add-PSSnapin citrix*
+
+########################################################
+# Step 1: Change the vTPM provision policy for the VM. #
+########################################################
+
+if ([string]::IsNullOrWhiteSpace($MachineProfile)) {
+    Set-ProvVM -ProvisioningSchemeName $ProvisioningSchemeName -VMName $VMName -VtpmProvisionPolicy $VtpmProvisionPolicy
+}
+else {
+    Set-ProvVM -ProvisioningSchemeName $ProvisioningSchemeName -VMName $VMName -VtpmProvisionPolicy $VtpmProvisionPolicy -MachineProfile $MachineProfile
+}


### PR DESCRIPTION
## Summary

Adds a new VMware ProvScheme example folder demonstrating the `-VtpmProvisionPolicy` parameter, which lets administrators control whether the vTPM of provisioned VMs is cloned from the source or created clean. The parameter currently takes effect on **VMware** only, and only when the machine profile contains a vTPM.

## Changes

New folder `VMware/ProvScheme/vTPM Provision Policy/`:
- `Create-ProvScheme-VtpmProvisionPolicy.ps1` — `New-ProvScheme`
- `Set-ProvScheme-VtpmProvisionPolicy.ps1` — `Set-ProvScheme`
- `Set-ProvVM-VtpmProvisionPolicy.ps1` — `Set-ProvVM`
- `New-ProvSchemeVersion-VtpmProvisionPolicy.ps1` — `New-ProvSchemeVersion` (experimental)
- `New-ProvVMConfiguration-VtpmProvisionPolicy.ps1` — `New-ProvVMConfiguration` (experimental)
- `README.md` — explains the policy values `None` (default), `Clone`, `Clean`

Updated `VMware/ProvScheme/README.md` to list the new feature folder.

## Notes
- Policy values: `None` (default; applied when the parameter is omitted), `Clone`, `Clean`.
- Files saved as UTF-8-BOM; scripts pass the PowerShell parser syntax check.
- Compatible with CVAD 7 2511 (first release containing the parameter).
- Mirrors the internal repo change reviewed and merged in citrix.provisioning.mcs-github-scripts (PMCS-52527).