### PR TITLE
PMCS-34681 PMCS-56449: Add -KeepPreparationVMOnFailure image-prep debugging samples for VMware and XenServer

### DIFF
--- a/VMware/ProvScheme/Image Prep Debugging/Create-ProvScheme-KeepPreparationVMOnFailure.ps1
+++ b/VMware/ProvScheme/Image Prep Debugging/Create-ProvScheme-KeepPreparationVMOnFailure.ps1
@@ -1,0 +1,100 @@
+﻿<#
+.SYNOPSIS
+    Creates a ProvScheme that keeps the image preparation VM on the hypervisor when image preparation fails.
+.DESCRIPTION
+    Create-ProvScheme-KeepPreparationVMOnFailure.ps1 creates a ProvScheme using the
+    -KeepPreparationVMOnFailure switch of New-ProvScheme.
+
+    By default MCS removes the temporary image preparation VM whether image preparation succeeds or
+    fails. When -KeepPreparationVMOnFailure is supplied and image preparation fails, the image
+    preparation VM and its resources are left on the hypervisor so the failure can be investigated.
+    If image preparation succeeds, the VM is removed automatically and the switch has no effect.
+
+    On a failed run the provisioning scheme is still created, but it is not operational.
+
+    The original version of this script is compatible with CVAD Cloud 123 (and the equivalent CVAD
+    on-prem release) and later.
+.INPUTS
+    1. ProvisioningSchemeName: Name of the new provisioning scheme.
+    2. IdentityPoolName: Name of the Identity Pool used.
+    3. HostingUnitName: Name of the hosting unit used.
+    4. ProvisioningSchemeType: The Provisioning Scheme Type.
+    5. MasterImageVM: Path to VM snapshot or template.
+    6. NetworkMapping: Specifies how the attached NICs are mapped to networks.
+    7. VMCpuCount: The number of processors that will be used to create VMs from the provisioning scheme.
+    8. VMMemoryMB: The maximum amount of memory that will be used to create VMs from the provisioning scheme in MB.
+    9. InitialBatchSizeHint: The number of initial VMs that will be added to the MCS catalog.
+    10. Scope: Administration scopes for the identity pool.
+    11. CustomProperties: Specific properties for the hosting infrastructure.
+    12. AdminAddress: The primary DDC address.
+.OUTPUTS
+    A New Provisioning Scheme Object
+.NOTES
+    Version      : 1.0.0
+    Author       : Citrix Systems, Inc.
+.EXAMPLE
+    .\Create-ProvScheme-KeepPreparationVMOnFailure.ps1 `
+        -ProvisioningSchemeName "MyMachineCatalog" `
+        -IdentityPoolName "MyMachineCatalog" `
+        -HostingUnitName "MyHostingUnit" `
+        -ProvisioningSchemeType "MCS" `
+        -MasterImageVM "XDHyp:\HostingUnits\MyHostingUnit\MyVM.vm\MySnapshot.snapshot" `
+        -NetworkMapping @{"0"="XDHyp:\HostingUnits\MyHostingUnit\MyNetwork.network"} `
+        -VMCpuCount 1 `
+        -VMMemoryMB 1024 `
+        -InitialBatchSizeHint 1 `
+        -Scope @() `
+        -CustomProperties "" `
+        -AdminAddress "MyDDC.MyDomain.local"
+#>
+
+# /*************************************************************************
+# * Copyright © 2026. Cloud Software Group, Inc. All Rights Reserved.
+# * This file is subject to the license terms contained
+# * in the license file that is distributed with this file.
+# *************************************************************************/
+
+param(
+    [string] $ProvisioningSchemeName,
+    [string] $IdentityPoolName,
+    [string] $HostingUnitName,
+    [string] $ProvisioningSchemeType,
+    [string] $MasterImageVM,
+    [hashtable] $NetworkMapping,
+    [string] $VMCpuCount,
+    [string] $VMMemoryMB,
+    [string] $InitialBatchSizeHint,
+    [string[]] $Scope,
+    [string] $CustomProperties,
+    [string] $AdminAddress = $null
+)
+
+# Enable Citrix PowerShell Cmdlets
+Add-PSSnapin citrix*
+
+# Convert the inputs into array formats.
+$Scope = @($Scope)
+
+# Configure the parameters for New-ProvScheme. CleanOnBoot and KeepPreparationVMOnFailure are always
+# set so that a failed image preparation leaves the preparation VM on the hypervisor for investigation.
+$newProvSchemeParameters = @{
+    ProvisioningSchemeName     = $ProvisioningSchemeName
+    IdentityPoolName           = $IdentityPoolName
+    HostingUnitName            = $HostingUnitName
+    ProvisioningSchemeType     = $ProvisioningSchemeType
+    MasterImageVM              = $MasterImageVM
+    NetworkMapping             = $NetworkMapping
+    VMCpuCount                 = $VMCpuCount
+    VMMemoryMB                 = $VMMemoryMB
+    InitialBatchSizeHint       = $InitialBatchSizeHint
+    Scope                      = $Scope
+    CustomProperties           = $CustomProperties
+    CleanOnBoot                = $true
+    KeepPreparationVMOnFailure = $true
+}
+
+# If operating in an On-Prem environment, configure the AdminAddress.
+if ($AdminAddress) { $newProvSchemeParameters['AdminAddress'] = $AdminAddress }
+
+# Create a Provisioning Scheme, keeping the image preparation VM on the hypervisor if image preparation fails.
+& New-ProvScheme @newProvSchemeParameters

--- a/VMware/ProvScheme/Image Prep Debugging/Get-ProvImagePrepVM.ps1
+++ b/VMware/ProvScheme/Image Prep Debugging/Get-ProvImagePrepVM.ps1
@@ -1,0 +1,57 @@
+﻿<#
+.SYNOPSIS
+    Finds the image preparation VM that was kept on the hypervisor after an image preparation failure.
+.DESCRIPTION
+    Get-ProvImagePrepVM.ps1 shows how to locate an image preparation VM that was retained on the
+    hypervisor by the -KeepPreparationVMOnFailure switch. Pass -ProvisioningSchemeName (or
+    -ProvisioningSchemeUid) to target a single scheme, or omit both to list the image preparation
+    VMs for all provisioning schemes that currently have one.
+
+    Use the returned details to find the VM on the hypervisor so its logs can be inspected. On
+    VMware, match the VM using the PreparationImageName field (in the form
+    "Preparation - <CatalogName>").
+
+    Get-ProvImagePrepVM requires CVAD Cloud 129 / CVAD 2611 CR or later.
+.INPUTS
+    1. ProvisioningSchemeName: Name of the provisioning scheme to query. Omit to list the image
+       preparation VMs for all provisioning schemes that currently have one.
+    2. AdminAddress: The primary DDC address.
+.OUTPUTS
+    Image preparation VM details for the matching provisioning scheme(s).
+.NOTES
+    Version      : 1.0.0
+    Author       : Citrix Systems, Inc.
+.EXAMPLE
+    # Retrieve the image preparation VM for a specific provisioning scheme.
+    .\Get-ProvImagePrepVM.ps1 `
+        -ProvisioningSchemeName "MyMachineCatalog" `
+        -AdminAddress "MyDDC.MyDomain.local"
+
+    # Omit -ProvisioningSchemeName to list the image preparation VMs for all provisioning schemes.
+    .\Get-ProvImagePrepVM.ps1
+#>
+
+# /*************************************************************************
+# * Copyright © 2026. Cloud Software Group, Inc. All Rights Reserved.
+# * This file is subject to the license terms contained
+# * in the license file that is distributed with this file.
+# *************************************************************************/
+
+param(
+    [string] $ProvisioningSchemeName,
+    [string] $AdminAddress = $null
+)
+
+# Enable Citrix PowerShell Cmdlets
+Add-PSSnapin citrix*
+
+# Configure the parameters for Get-ProvImagePrepVM. Omit -ProvisioningSchemeName to list the image
+# preparation VMs for all provisioning schemes that currently have one.
+$getParameters = @{}
+if ($ProvisioningSchemeName) { $getParameters['ProvisioningSchemeName'] = $ProvisioningSchemeName }
+
+# If operating in an On-Prem environment, configure the AdminAddress.
+if ($AdminAddress) { $getParameters['AdminAddress'] = $AdminAddress }
+
+# Retrieve image preparation VM details.
+& Get-ProvImagePrepVM @getParameters

--- a/VMware/ProvScheme/Image Prep Debugging/README.md
+++ b/VMware/ProvScheme/Image Prep Debugging/README.md
@@ -1,0 +1,62 @@
+﻿# Troubleshooting image preparation failures with the image preparation VM (VMware)
+
+This folder shows how to use the `-KeepPreparationVMOnFailure` parameter of `New-ProvScheme` and `Publish-ProvMasterVMImage` so that, on VMware, the image preparation VM is kept on the hypervisor when image preparation fails. It also shows how to find, inspect, and remove the retained VM using `Get-ProvImagePrepVM` and `Remove-ProvImagePrepVM`.
+
+## 1. Understanding the -KeepPreparationVMOnFailure feature
+
+Image preparation runs on a temporary VM that MCS creates from your master image. By default this VM and its resources are removed when preparation finishes, whether it succeeds or fails. When a failure cannot be diagnosed from the returned error (for example, `No Image Preparation results found. There may be no suitable VDA installed, or some other serious failure in the Master VM. Image preparation failed`), the logs on the image preparation VM are often the only way to find the root cause.
+
+Supplying `-KeepPreparationVMOnFailure` changes the behavior on failure only:
+
+- If image preparation **succeeds**, the image preparation VM is removed automatically (the switch has no effect).
+- If image preparation **fails**, the image preparation VM and its resources are left on the hypervisor so you can connect to it and inspect the logs.
+
+For `New-ProvScheme`, a failed run still creates the provisioning scheme, but it is not operational. For `Publish-ProvMasterVMImage`, the provisioning scheme keeps running on the previous master image.
+
+## 2. Using the feature
+
+### Enable it when creating a catalog or updating an image
+
+Add the switch to `New-ProvScheme` or `Publish-ProvMasterVMImage`:
+
+```powershell
+New-ProvScheme `
+    -ProvisioningSchemeName "MyMachineCatalog" `
+    # Additional parameters... `
+    -KeepPreparationVMOnFailure
+```
+
+```powershell
+Publish-ProvMasterVMImage `
+    -ProvisioningSchemeName "MyMachineCatalog" `
+    # Additional parameters... `
+    -KeepPreparationVMOnFailure
+```
+
+### Find the retained image preparation VM
+
+Use `Get-ProvImagePrepVM` to retrieve details of the retained VM. On VMware, locate the VM in vSphere using the **PreparationImageName** field, in the form `Preparation - <CatalogName>`.
+
+### Inspect the logs
+
+1. Power on the image preparation VM and open the vSphere console (Launch Web Console), logging in if prompted.
+2. Browse to `%programdata%\Citrix\ImagePreparation`. If prompted with a security prompt, press **Continue**.
+3. Open `image-prep.log`, or copy it off the VM to provide to support for troubleshooting.
+
+### Remove it when finished
+
+When troubleshooting is complete, remove the VM and its resources with `Remove-ProvImagePrepVM`. Deleting the machine catalog, or re-running `Publish-ProvMasterVMImage` for the same scheme, also removes it automatically.
+
+## 3. Example Full Scripts
+
+1. [Create a catalog that keeps the image preparation VM on failure](Create-ProvScheme-KeepPreparationVMOnFailure.ps1)
+2. [Update a master image, keeping the image preparation VM on failure](Update-MasterImage-KeepPreparationVMOnFailure.ps1)
+3. [Find the retained image preparation VM](Get-ProvImagePrepVM.ps1)
+4. [Remove the retained image preparation VM](Remove-ProvImagePrepVM.ps1)
+
+## 4. Reference Documents
+
+1. Keep the image preparation VM on failure — Citrix Knowledge Base article (pending publication).
+2. [CVAD SDK - Machine Creation cmdlets](https://developer-docs.citrix.com/en-us/citrix-daas-sdk/machinecreation/)
+
+> **Compatibility:** `-KeepPreparationVMOnFailure` requires CVAD Cloud 123 or later. `Get-ProvImagePrepVM` and `Remove-ProvImagePrepVM` require CVAD Cloud 129 / CVAD 2611 CR or later.

--- a/VMware/ProvScheme/Image Prep Debugging/Remove-ProvImagePrepVM.ps1
+++ b/VMware/ProvScheme/Image Prep Debugging/Remove-ProvImagePrepVM.ps1
@@ -1,0 +1,55 @@
+﻿<#
+.SYNOPSIS
+    Removes an image preparation VM that was kept on the hypervisor after an image preparation failure.
+.DESCRIPTION
+    Remove-ProvImagePrepVM.ps1 removes the image preparation VM and its associated resources for a
+    provisioning scheme once troubleshooting is complete. Target the scheme with
+    -ProvisioningSchemeName or -ProvisioningSchemeUid, or pipe a provisioning scheme into the cmdlet.
+
+    The image preparation VM is also removed automatically when the machine catalog is deleted, or
+    when Publish-ProvMasterVMImage is run again for the same scheme.
+
+    Remove-ProvImagePrepVM requires CVAD Cloud 129 / CVAD 2611 CR or later.
+.INPUTS
+    1. ProvisioningSchemeName: Name of the provisioning scheme whose image preparation VM will be removed.
+    2. AdminAddress: The primary DDC address.
+
+    A provisioning scheme object can also be piped in (ProvisioningSchemeName / ProvisioningSchemeUid).
+.OUTPUTS
+    N/A
+.NOTES
+    Version      : 1.0.0
+    Author       : Citrix Systems, Inc.
+.EXAMPLE
+    .\Remove-ProvImagePrepVM.ps1 `
+        -ProvisioningSchemeName "MyMachineCatalog" `
+        -AdminAddress "MyDDC.MyDomain.local"
+#>
+
+# /*************************************************************************
+# * Copyright © 2026. Cloud Software Group, Inc. All Rights Reserved.
+# * This file is subject to the license terms contained
+# * in the license file that is distributed with this file.
+# *************************************************************************/
+
+param(
+    [string] $ProvisioningSchemeName,
+    [string] $AdminAddress = $null
+)
+
+# Enable Citrix PowerShell Cmdlets
+Add-PSSnapin citrix*
+
+# Configure the parameters for Remove-ProvImagePrepVM.
+$removeParameters = @{
+    ProvisioningSchemeName = $ProvisioningSchemeName
+}
+
+# If operating in an On-Prem environment, configure the AdminAddress.
+if ($AdminAddress) { $removeParameters['AdminAddress'] = $AdminAddress }
+
+# Remove the image preparation VM (and its resources) for the provisioning scheme.
+& Remove-ProvImagePrepVM @removeParameters
+
+# Alternatively, pipe a provisioning scheme into Remove-ProvImagePrepVM:
+# Get-ProvScheme -ProvisioningSchemeName $ProvisioningSchemeName | Remove-ProvImagePrepVM

--- a/VMware/ProvScheme/Image Prep Debugging/Update-MasterImage-KeepPreparationVMOnFailure.ps1
+++ b/VMware/ProvScheme/Image Prep Debugging/Update-MasterImage-KeepPreparationVMOnFailure.ps1
@@ -1,0 +1,61 @@
+﻿<#
+.SYNOPSIS
+    Updates the master image of a ProvScheme, keeping the image preparation VM on failure.
+.DESCRIPTION
+    Update-MasterImage-KeepPreparationVMOnFailure.ps1 updates the master image of an existing
+    provisioning scheme using Publish-ProvMasterVMImage with the -KeepPreparationVMOnFailure switch.
+
+    When image preparation fails, the image preparation VM and its resources are left on the
+    hypervisor so the failure can be investigated. If image preparation succeeds, the VM is removed
+    automatically and the switch has no effect. On a failed run the provisioning scheme keeps running
+    on the previous master image.
+
+    Re-running Publish-ProvMasterVMImage for the same scheme automatically removes any image
+    preparation VM left by the previous failed attempt.
+
+    The original version of this script is compatible with CVAD Cloud 123 (and the equivalent CVAD
+    on-prem release) and later.
+.INPUTS
+    1. ProvisioningSchemeName: Name of the provisioning scheme whose master image will be updated.
+    2. MasterImageVM: Path to the new VM snapshot or template.
+    3. AdminAddress: The primary DDC address.
+.OUTPUTS
+    N/A
+.NOTES
+    Version      : 1.0.0
+    Author       : Citrix Systems, Inc.
+.EXAMPLE
+    .\Update-MasterImage-KeepPreparationVMOnFailure.ps1 `
+        -ProvisioningSchemeName "MyMachineCatalog" `
+        -MasterImageVM "XDHyp:\HostingUnits\MyHostingUnit\MyVM.vm\MyNewSnapshot.snapshot" `
+        -AdminAddress "MyDDC.MyDomain.local"
+#>
+
+# /*************************************************************************
+# * Copyright © 2026. Cloud Software Group, Inc. All Rights Reserved.
+# * This file is subject to the license terms contained
+# * in the license file that is distributed with this file.
+# *************************************************************************/
+
+param(
+    [string] $ProvisioningSchemeName,
+    [string] $MasterImageVM,
+    [string] $AdminAddress = $null
+)
+
+# Enable Citrix PowerShell Cmdlets
+Add-PSSnapin citrix*
+
+# Configure the parameters for Publish-ProvMasterVMImage. KeepPreparationVMOnFailure is always set so
+# that a failed image preparation leaves the preparation VM on the hypervisor for investigation.
+$publishParameters = @{
+    ProvisioningSchemeName     = $ProvisioningSchemeName
+    MasterImageVM              = $MasterImageVM
+    KeepPreparationVMOnFailure = $true
+}
+
+# If operating in an On-Prem environment, configure the AdminAddress.
+if ($AdminAddress) { $publishParameters['AdminAddress'] = $AdminAddress }
+
+# Update the master image, keeping the image preparation VM on the hypervisor if image preparation fails.
+& Publish-ProvMasterVMImage @publishParameters

--- a/VMware/ProvScheme/README.md
+++ b/VMware/ProvScheme/README.md
@@ -24,3 +24,7 @@ The following folders explain the VMware features for **ProvScheme**:
 * [Data Disk](./Data%20Disk/): Descriptions for utilizing Data Disk.
 * [Folder Id](./Folder%20ID/): Descriptions for updating Folder Id.
 * [vTPM Provision Policy](./vTPM%20Provision%20Policy/): Descriptions for controlling the vTPM provision policy (None, Clone, Clean).
+
+## 3. Troubleshooting Image Preparation Failures
+
+* [Image Prep Debugging](./Image%20Prep%20Debugging/): Keep the image preparation VM on failure so its logs can be inspected, then find and remove it.

--- a/XenServer/ProvScheme/Image Prep Debugging/Create-ProvScheme-KeepPreparationVMOnFailure.ps1
+++ b/XenServer/ProvScheme/Image Prep Debugging/Create-ProvScheme-KeepPreparationVMOnFailure.ps1
@@ -1,0 +1,100 @@
+﻿<#
+.SYNOPSIS
+    Creates a ProvScheme that keeps the image preparation VM on the hypervisor when image preparation fails.
+.DESCRIPTION
+    Create-ProvScheme-KeepPreparationVMOnFailure.ps1 creates a ProvScheme using the
+    -KeepPreparationVMOnFailure switch of New-ProvScheme.
+
+    By default MCS removes the temporary image preparation VM whether image preparation succeeds or
+    fails. When -KeepPreparationVMOnFailure is supplied and image preparation fails, the image
+    preparation VM and its resources are left on the hypervisor so the failure can be investigated.
+    If image preparation succeeds, the VM is removed automatically and the switch has no effect.
+
+    On a failed run the provisioning scheme is still created, but it is not operational.
+
+    The original version of this script is compatible with CVAD Cloud 123 (and the equivalent CVAD
+    on-prem release) and later.
+.INPUTS
+    1. ProvisioningSchemeName: Name of the new provisioning scheme.
+    2. IdentityPoolName: Name of the Identity Pool used.
+    3. HostingUnitName: Name of the hosting unit used.
+    4. ProvisioningSchemeType: The Provisioning Scheme Type.
+    5. MasterImageVM: Path to VM snapshot or template.
+    6. NetworkMapping: Specifies how the attached NICs are mapped to networks.
+    7. VMCpuCount: The number of processors that will be used to create VMs from the provisioning scheme.
+    8. VMMemoryMB: The maximum amount of memory that will be used to create VMs from the provisioning scheme in MB.
+    9. InitialBatchSizeHint: The number of initial VMs that will be added to the MCS catalog.
+    10. Scope: Administration scopes for the identity pool.
+    11. CustomProperties: Specific properties for the hosting infrastructure.
+    12. AdminAddress: The primary DDC address.
+.OUTPUTS
+    A New Provisioning Scheme Object
+.NOTES
+    Version      : 1.0.0
+    Author       : Citrix Systems, Inc.
+.EXAMPLE
+    .\Create-ProvScheme-KeepPreparationVMOnFailure.ps1 `
+        -ProvisioningSchemeName "MyMachineCatalog" `
+        -IdentityPoolName "MyMachineCatalog" `
+        -HostingUnitName "MyHostingUnit" `
+        -ProvisioningSchemeType "MCS" `
+        -MasterImageVM "XDHyp:\HostingUnits\MyHostingUnit\MyVM.vm\MySnapshot.snapshot" `
+        -NetworkMapping @{"0"="XDHyp:\HostingUnits\MyHostingUnit\MyNetwork.network"} `
+        -VMCpuCount 1 `
+        -VMMemoryMB 1024 `
+        -InitialBatchSizeHint 1 `
+        -Scope @() `
+        -CustomProperties "" `
+        -AdminAddress "MyDDC.MyDomain.local"
+#>
+
+# /*************************************************************************
+# * Copyright © 2026. Cloud Software Group, Inc. All Rights Reserved.
+# * This file is subject to the license terms contained
+# * in the license file that is distributed with this file.
+# *************************************************************************/
+
+param(
+    [string] $ProvisioningSchemeName,
+    [string] $IdentityPoolName,
+    [string] $HostingUnitName,
+    [string] $ProvisioningSchemeType,
+    [string] $MasterImageVM,
+    [hashtable] $NetworkMapping,
+    [string] $VMCpuCount,
+    [string] $VMMemoryMB,
+    [string] $InitialBatchSizeHint,
+    [string[]] $Scope,
+    [string] $CustomProperties,
+    [string] $AdminAddress = $null
+)
+
+# Enable Citrix PowerShell Cmdlets
+Add-PSSnapin citrix*
+
+# Convert the inputs into array formats.
+$Scope = @($Scope)
+
+# Configure the parameters for New-ProvScheme. CleanOnBoot and KeepPreparationVMOnFailure are always
+# set so that a failed image preparation leaves the preparation VM on the hypervisor for investigation.
+$newProvSchemeParameters = @{
+    ProvisioningSchemeName     = $ProvisioningSchemeName
+    IdentityPoolName           = $IdentityPoolName
+    HostingUnitName            = $HostingUnitName
+    ProvisioningSchemeType     = $ProvisioningSchemeType
+    MasterImageVM              = $MasterImageVM
+    NetworkMapping             = $NetworkMapping
+    VMCpuCount                 = $VMCpuCount
+    VMMemoryMB                 = $VMMemoryMB
+    InitialBatchSizeHint       = $InitialBatchSizeHint
+    Scope                      = $Scope
+    CustomProperties           = $CustomProperties
+    CleanOnBoot                = $true
+    KeepPreparationVMOnFailure = $true
+}
+
+# If operating in an On-Prem environment, configure the AdminAddress.
+if ($AdminAddress) { $newProvSchemeParameters['AdminAddress'] = $AdminAddress }
+
+# Create a Provisioning Scheme, keeping the image preparation VM on the hypervisor if image preparation fails.
+& New-ProvScheme @newProvSchemeParameters

--- a/XenServer/ProvScheme/Image Prep Debugging/Get-ProvImagePrepVM.ps1
+++ b/XenServer/ProvScheme/Image Prep Debugging/Get-ProvImagePrepVM.ps1
@@ -1,0 +1,57 @@
+﻿<#
+.SYNOPSIS
+    Finds the image preparation VM that was kept on the hypervisor after an image preparation failure.
+.DESCRIPTION
+    Get-ProvImagePrepVM.ps1 shows how to locate an image preparation VM that was retained on the
+    hypervisor by the -KeepPreparationVMOnFailure switch. Pass -ProvisioningSchemeName (or
+    -ProvisioningSchemeUid) to target a single scheme, or omit both to list the image preparation
+    VMs for all provisioning schemes that currently have one.
+
+    Use the returned details to find the VM on the hypervisor so its logs can be inspected. On
+    XenServer, match the VM in XenCenter using either the PreparationImageName field (in the form
+    "Preparation - <CatalogName>") or the VM UUID, which matches the returned ImagePrepVMId.
+
+    Get-ProvImagePrepVM requires CVAD Cloud 129 / CVAD 2611 CR or later.
+.INPUTS
+    1. ProvisioningSchemeName: Name of the provisioning scheme to query. Omit to list the image
+       preparation VMs for all provisioning schemes that currently have one.
+    2. AdminAddress: The primary DDC address.
+.OUTPUTS
+    Image preparation VM details for the matching provisioning scheme(s).
+.NOTES
+    Version      : 1.0.0
+    Author       : Citrix Systems, Inc.
+.EXAMPLE
+    # Retrieve the image preparation VM for a specific provisioning scheme.
+    .\Get-ProvImagePrepVM.ps1 `
+        -ProvisioningSchemeName "MyMachineCatalog" `
+        -AdminAddress "MyDDC.MyDomain.local"
+
+    # Omit -ProvisioningSchemeName to list the image preparation VMs for all provisioning schemes.
+    .\Get-ProvImagePrepVM.ps1
+#>
+
+# /*************************************************************************
+# * Copyright © 2026. Cloud Software Group, Inc. All Rights Reserved.
+# * This file is subject to the license terms contained
+# * in the license file that is distributed with this file.
+# *************************************************************************/
+
+param(
+    [string] $ProvisioningSchemeName,
+    [string] $AdminAddress = $null
+)
+
+# Enable Citrix PowerShell Cmdlets
+Add-PSSnapin citrix*
+
+# Configure the parameters for Get-ProvImagePrepVM. Omit -ProvisioningSchemeName to list the image
+# preparation VMs for all provisioning schemes that currently have one.
+$getParameters = @{}
+if ($ProvisioningSchemeName) { $getParameters['ProvisioningSchemeName'] = $ProvisioningSchemeName }
+
+# If operating in an On-Prem environment, configure the AdminAddress.
+if ($AdminAddress) { $getParameters['AdminAddress'] = $AdminAddress }
+
+# Retrieve image preparation VM details.
+& Get-ProvImagePrepVM @getParameters

--- a/XenServer/ProvScheme/Image Prep Debugging/README.md
+++ b/XenServer/ProvScheme/Image Prep Debugging/README.md
@@ -1,0 +1,65 @@
+﻿# Troubleshooting image preparation failures with the image preparation VM (XenServer)
+
+This folder shows how to use the `-KeepPreparationVMOnFailure` parameter of `New-ProvScheme` and `Publish-ProvMasterVMImage` so that, on XenServer, the image preparation VM is kept on the hypervisor when image preparation fails. It also shows how to find, inspect, and remove the retained VM using `Get-ProvImagePrepVM` and `Remove-ProvImagePrepVM`.
+
+## 1. Understanding the -KeepPreparationVMOnFailure feature
+
+Image preparation runs on a temporary VM that MCS creates from your master image. By default this VM and its resources are removed when preparation finishes, whether it succeeds or fails. When a failure cannot be diagnosed from the returned error (for example, `No Image Preparation results found. There may be no suitable VDA installed, or some other serious failure in the Master VM. Image preparation failed`), the logs on the image preparation VM are often the only way to find the root cause.
+
+Supplying `-KeepPreparationVMOnFailure` changes the behavior on failure only:
+
+- If image preparation **succeeds**, the image preparation VM is removed automatically (the switch has no effect).
+- If image preparation **fails**, the image preparation VM and its resources are left on the hypervisor so you can connect to it and inspect the logs.
+
+For `New-ProvScheme`, a failed run still creates the provisioning scheme, but it is not operational. For `Publish-ProvMasterVMImage`, the provisioning scheme keeps running on the previous master image.
+
+## 2. Using the feature
+
+### Enable it when creating a catalog or updating an image
+
+Add the switch to `New-ProvScheme` or `Publish-ProvMasterVMImage`:
+
+```powershell
+New-ProvScheme `
+    -ProvisioningSchemeName "MyMachineCatalog" `
+    # Additional parameters... `
+    -KeepPreparationVMOnFailure
+```
+
+```powershell
+Publish-ProvMasterVMImage `
+    -ProvisioningSchemeName "MyMachineCatalog" `
+    # Additional parameters... `
+    -KeepPreparationVMOnFailure
+```
+
+### Find the retained image preparation VM
+
+Use `Get-ProvImagePrepVM` to retrieve details of the retained VM. On XenServer, locate the VM in XenCenter using either:
+
+- **PreparationImageName** — in the form `Preparation - <CatalogName>`
+- The VM **UUID**, which matches the `ImagePrepVMId` from the cmdlet output (visible on the VM's **General** tab in XenCenter)
+
+### Inspect the logs
+
+1. Select the image preparation VM in XenCenter, power it on, and open the **Console** tab, logging in if prompted.
+2. Browse to `%programdata%\Citrix\ImagePreparation`. If prompted with a security prompt, press **Continue**.
+3. Open `image-prep.log`, or copy it off the VM to provide to support for troubleshooting.
+
+### Remove it when finished
+
+When troubleshooting is complete, remove the VM and its resources with `Remove-ProvImagePrepVM`. Deleting the machine catalog, or re-running `Publish-ProvMasterVMImage` for the same scheme, also removes it automatically.
+
+## 3. Example Full Scripts
+
+1. [Create a catalog that keeps the image preparation VM on failure](Create-ProvScheme-KeepPreparationVMOnFailure.ps1)
+2. [Update a master image, keeping the image preparation VM on failure](Update-MasterImage-KeepPreparationVMOnFailure.ps1)
+3. [Find the retained image preparation VM](Get-ProvImagePrepVM.ps1)
+4. [Remove the retained image preparation VM](Remove-ProvImagePrepVM.ps1)
+
+## 4. Reference Documents
+
+1. Keep the image preparation VM on failure — Citrix Knowledge Base article (pending publication).
+2. [CVAD SDK - Machine Creation cmdlets](https://developer-docs.citrix.com/en-us/citrix-daas-sdk/machinecreation/)
+
+> **Compatibility:** `-KeepPreparationVMOnFailure` requires CVAD Cloud 123 or later. `Get-ProvImagePrepVM` and `Remove-ProvImagePrepVM` require CVAD Cloud 129 / CVAD 2611 CR or later.

--- a/XenServer/ProvScheme/Image Prep Debugging/Remove-ProvImagePrepVM.ps1
+++ b/XenServer/ProvScheme/Image Prep Debugging/Remove-ProvImagePrepVM.ps1
@@ -1,0 +1,55 @@
+﻿<#
+.SYNOPSIS
+    Removes an image preparation VM that was kept on the hypervisor after an image preparation failure.
+.DESCRIPTION
+    Remove-ProvImagePrepVM.ps1 removes the image preparation VM and its associated resources for a
+    provisioning scheme once troubleshooting is complete. Target the scheme with
+    -ProvisioningSchemeName or -ProvisioningSchemeUid, or pipe a provisioning scheme into the cmdlet.
+
+    The image preparation VM is also removed automatically when the machine catalog is deleted, or
+    when Publish-ProvMasterVMImage is run again for the same scheme.
+
+    Remove-ProvImagePrepVM requires CVAD Cloud 129 / CVAD 2611 CR or later.
+.INPUTS
+    1. ProvisioningSchemeName: Name of the provisioning scheme whose image preparation VM will be removed.
+    2. AdminAddress: The primary DDC address.
+
+    A provisioning scheme object can also be piped in (ProvisioningSchemeName / ProvisioningSchemeUid).
+.OUTPUTS
+    N/A
+.NOTES
+    Version      : 1.0.0
+    Author       : Citrix Systems, Inc.
+.EXAMPLE
+    .\Remove-ProvImagePrepVM.ps1 `
+        -ProvisioningSchemeName "MyMachineCatalog" `
+        -AdminAddress "MyDDC.MyDomain.local"
+#>
+
+# /*************************************************************************
+# * Copyright © 2026. Cloud Software Group, Inc. All Rights Reserved.
+# * This file is subject to the license terms contained
+# * in the license file that is distributed with this file.
+# *************************************************************************/
+
+param(
+    [string] $ProvisioningSchemeName,
+    [string] $AdminAddress = $null
+)
+
+# Enable Citrix PowerShell Cmdlets
+Add-PSSnapin citrix*
+
+# Configure the parameters for Remove-ProvImagePrepVM.
+$removeParameters = @{
+    ProvisioningSchemeName = $ProvisioningSchemeName
+}
+
+# If operating in an On-Prem environment, configure the AdminAddress.
+if ($AdminAddress) { $removeParameters['AdminAddress'] = $AdminAddress }
+
+# Remove the image preparation VM (and its resources) for the provisioning scheme.
+& Remove-ProvImagePrepVM @removeParameters
+
+# Alternatively, pipe a provisioning scheme into Remove-ProvImagePrepVM:
+# Get-ProvScheme -ProvisioningSchemeName $ProvisioningSchemeName | Remove-ProvImagePrepVM

--- a/XenServer/ProvScheme/Image Prep Debugging/Update-MasterImage-KeepPreparationVMOnFailure.ps1
+++ b/XenServer/ProvScheme/Image Prep Debugging/Update-MasterImage-KeepPreparationVMOnFailure.ps1
@@ -1,0 +1,61 @@
+﻿<#
+.SYNOPSIS
+    Updates the master image of a ProvScheme, keeping the image preparation VM on failure.
+.DESCRIPTION
+    Update-MasterImage-KeepPreparationVMOnFailure.ps1 updates the master image of an existing
+    provisioning scheme using Publish-ProvMasterVMImage with the -KeepPreparationVMOnFailure switch.
+
+    When image preparation fails, the image preparation VM and its resources are left on the
+    hypervisor so the failure can be investigated. If image preparation succeeds, the VM is removed
+    automatically and the switch has no effect. On a failed run the provisioning scheme keeps running
+    on the previous master image.
+
+    Re-running Publish-ProvMasterVMImage for the same scheme automatically removes any image
+    preparation VM left by the previous failed attempt.
+
+    The original version of this script is compatible with CVAD Cloud 123 (and the equivalent CVAD
+    on-prem release) and later.
+.INPUTS
+    1. ProvisioningSchemeName: Name of the provisioning scheme whose master image will be updated.
+    2. MasterImageVM: Path to the new VM snapshot or template.
+    3. AdminAddress: The primary DDC address.
+.OUTPUTS
+    N/A
+.NOTES
+    Version      : 1.0.0
+    Author       : Citrix Systems, Inc.
+.EXAMPLE
+    .\Update-MasterImage-KeepPreparationVMOnFailure.ps1 `
+        -ProvisioningSchemeName "MyMachineCatalog" `
+        -MasterImageVM "XDHyp:\HostingUnits\MyHostingUnit\MyVM.vm\MyNewSnapshot.snapshot" `
+        -AdminAddress "MyDDC.MyDomain.local"
+#>
+
+# /*************************************************************************
+# * Copyright © 2026. Cloud Software Group, Inc. All Rights Reserved.
+# * This file is subject to the license terms contained
+# * in the license file that is distributed with this file.
+# *************************************************************************/
+
+param(
+    [string] $ProvisioningSchemeName,
+    [string] $MasterImageVM,
+    [string] $AdminAddress = $null
+)
+
+# Enable Citrix PowerShell Cmdlets
+Add-PSSnapin citrix*
+
+# Configure the parameters for Publish-ProvMasterVMImage. KeepPreparationVMOnFailure is always set so
+# that a failed image preparation leaves the preparation VM on the hypervisor for investigation.
+$publishParameters = @{
+    ProvisioningSchemeName     = $ProvisioningSchemeName
+    MasterImageVM              = $MasterImageVM
+    KeepPreparationVMOnFailure = $true
+}
+
+# If operating in an On-Prem environment, configure the AdminAddress.
+if ($AdminAddress) { $publishParameters['AdminAddress'] = $AdminAddress }
+
+# Update the master image, keeping the image preparation VM on the hypervisor if image preparation fails.
+& Publish-ProvMasterVMImage @publishParameters

--- a/XenServer/ProvScheme/README.md
+++ b/XenServer/ProvScheme/README.md
@@ -21,3 +21,7 @@ The following folders explain the XenServer features for **ProvScheme**:
 
 * [Full Clone](./Full%20Clone/): Descriptions for utilizing Full Clone.
 * [Write-Back Cache](./Write-Back%20Cache/): Descriptions for utilizing Write-Back Cache.
+
+## 3. Troubleshooting Image Preparation Failures
+
+* [Image Prep Debugging](./Image%20Prep%20Debugging/): Keep the image preparation VM on failure so its logs can be inspected, then find and remove it.


### PR DESCRIPTION
PMCS-34681 PMCS-56449: Add -KeepPreparationVMOnFailure image-prep debugging samples for VMware and XenServer

Samples cover retaining the image preparation VM on failure via `New-ProvScheme` / `Publish-ProvMasterVMImage` `-KeepPreparationVMOnFailure`, and finding/removing the retained VM with `Get-ProvImagePrepVM` / `Remove-ProvImagePrepVM`.