### PR TITLE
PMCS-64195: Add image definition scope examples

### DIFF
--- a/Amazon WorkSpaces Core/Image Management/Add-ImageDefinitionScope.ps1
+++ b/Amazon WorkSpaces Core/Image Management/Add-ImageDefinitionScope.ps1
@@ -1,0 +1,26 @@
+<#
+.SYNOPSIS
+    Adds one or more scopes to an existing image definition.
+.DESCRIPTION
+    Add-ImageDefinitionScope.ps1 adds the specified scope(s) to an existing image definition.
+    The original version of this script is compatible with Citrix DaaS DDC 129.
+.INPUTS
+    1. DefinitionName: Name(s) of the image definition.
+    2. Scope: One or more scope names to add to the image definition.
+#>
+
+# /*************************************************************************
+# * Copyright © 2025. Cloud Software Group, Inc. All Rights Reserved.
+# * This file is subject to the license terms contained
+# * in the license file that is distributed with this file.
+# *************************************************************************/
+
+param(
+    [string[]]$DefinitionName,
+    [string[]]$Scope
+)
+
+# Enable Citrix PowerShell Cmdlets
+Add-PSSnapin -Name "Citrix.Host.Admin.V2", "Citrix.MachineCreation.Admin.V2"
+
+Add-ProvImageDefinitionScope -ImageDefinitionName $DefinitionName -Scope $Scope

--- a/Amazon WorkSpaces Core/Image Management/Create-ImageDefinitionAndVersion.ps1
+++ b/Amazon WorkSpaces Core/Image Management/Create-ImageDefinitionAndVersion.ps1
@@ -12,6 +12,7 @@
     5. NetworkMapping: Specifies how the attached NICs are mapped to networks.
     6. ServiceOffering: The service offering used.
     7. MachineProfile: The machine profile used.
+    8. Scope: One or more administrative scope names to assign to the image definition. Optional; defaults to none.
 #>
 
 # /*************************************************************************
@@ -26,13 +27,25 @@ param(
     [string]$HostingUnitName,
     [string]$MasterImage,
     [hashtable]$NetworkMapping,
-    [string]$MachineProfile
+    [string]$MachineProfile,
+    [Parameter(Mandatory = $false)][string[]]$Scope = @()
 )
 
 # Enable Citrix PowerShell Cmdlets
 Add-PSSnapin -Name "Citrix.Host.Admin.V2", "Citrix.MachineCreation.Admin.V2"
 
-$Definition = New-ProvImageDefinition -ImageDefinitionName $DefinitionName -OsType Windows -VDASessionSupport MultiSession
+$NewDefinitionParams = @{
+    ImageDefinitionName = $DefinitionName
+    OsType              = "Windows"
+    VDASessionSupport   = "MultiSession"
+}
+
+# The -Scope parameter requires Citrix DaaS DDC 129 or later. Only pass it when scopes are supplied.
+if ($Scope) {
+    $NewDefinitionParams["Scope"] = $Scope
+}
+
+$Definition = New-ProvImageDefinition @NewDefinitionParams
 
 $Version = New-ProvImageVersion -ImageDefinitionName $Definition.ImageDefinitionName
 

--- a/Amazon WorkSpaces Core/Image Management/README.md
+++ b/Amazon WorkSpaces Core/Image Management/README.md
@@ -19,6 +19,27 @@ Image definition is a logical grouping of versions of an Image. An Image Definit
 New-ProvImageDefinition -ImageDefinitionName "demo" -OsType Windows -VDASessionSupport MultiSession
 ```
 
+### Image Definition Scope
+Requires Citrix DaaS DDC 129 or later.
+
+You can assign administrative scopes to an image definition at creation time using the optional `-Scope` parameter:
+
+```powershell
+New-ProvImageDefinition -ImageDefinitionName "demo" -OsType Windows -VDASessionSupport MultiSession -Scope @("ScopeA", "ScopeB")
+```
+
+Add scopes to an existing image definition:
+
+```powershell
+Add-ProvImageDefinitionScope -ImageDefinitionName "demo" -Scope @("ScopeA")
+```
+
+Remove scopes from an existing image definition:
+
+```powershell
+Remove-ProvImageDefinitionScope -ImageDefinitionName "demo" -Scope @("ScopeA")
+```
+
 ### Image Definition Connection
 Image definition connection is the hypervisor connection which holds master images.
 

--- a/Amazon WorkSpaces Core/Image Management/Remove-ImageDefinitionScope.ps1
+++ b/Amazon WorkSpaces Core/Image Management/Remove-ImageDefinitionScope.ps1
@@ -1,0 +1,26 @@
+<#
+.SYNOPSIS
+    Removes one or more scopes from an existing image definition.
+.DESCRIPTION
+    Remove-ImageDefinitionScope.ps1 removes the specified scope(s) from an existing image definition.
+    The original version of this script is compatible with Citrix DaaS DDC 129.
+.INPUTS
+    1. DefinitionName: Name(s) of the image definition.
+    2. Scope: One or more scope names to remove from the image definition.
+#>
+
+# /*************************************************************************
+# * Copyright © 2025. Cloud Software Group, Inc. All Rights Reserved.
+# * This file is subject to the license terms contained
+# * in the license file that is distributed with this file.
+# *************************************************************************/
+
+param(
+    [string[]]$DefinitionName,
+    [string[]]$Scope
+)
+
+# Enable Citrix PowerShell Cmdlets
+Add-PSSnapin -Name "Citrix.Host.Admin.V2", "Citrix.MachineCreation.Admin.V2"
+
+Remove-ProvImageDefinitionScope -ImageDefinitionName $DefinitionName -Scope $Scope

--- a/Azure/Image Management/Add-ImageDefinitionScope.ps1
+++ b/Azure/Image Management/Add-ImageDefinitionScope.ps1
@@ -1,0 +1,26 @@
+<#
+.SYNOPSIS
+    Adds one or more scopes to an existing image definition.
+.DESCRIPTION
+    Add-ImageDefinitionScope.ps1 adds the specified scope(s) to an existing image definition.
+    The original version of this script is compatible with Citrix DaaS DDC 129.
+.INPUTS
+    1. DefinitionName: Name(s) of the image definition.
+    2. Scope: One or more scope names to add to the image definition.
+#>
+
+# /*************************************************************************
+# * Copyright © 2025. Cloud Software Group, Inc. All Rights Reserved.
+# * This file is subject to the license terms contained
+# * in the license file that is distributed with this file.
+# *************************************************************************/
+
+param(
+    [string[]]$DefinitionName,
+    [string[]]$Scope
+)
+
+# Enable Citrix PowerShell Cmdlets
+Add-PSSnapin -Name "Citrix.Host.Admin.V2", "Citrix.MachineCreation.Admin.V2"
+
+Add-ProvImageDefinitionScope -ImageDefinitionName $DefinitionName -Scope $Scope

--- a/Azure/Image Management/Create-ImageDefinitionAndVersion.ps1
+++ b/Azure/Image Management/Create-ImageDefinitionAndVersion.ps1
@@ -29,6 +29,7 @@
        - DiskEncryptionSetId: Azure Disk Encryption Set ID for server-side encryption. Must be a 
          valid Azure resource ID. If not specified, platform-managed encryption is used. Cannot 
          be changed after the prepared image is created.
+    10. Scope: One or more administrative scope names to assign to the image definition. Optional; defaults to none.
 #>
 
 # /*************************************************************************
@@ -46,13 +47,25 @@ param(
     [string]$ServiceOffering,
     [Parameter(Mandatory = $false)][string]$MachineProfile,
     [Parameter(Mandatory = $false)][string]$ConnCustomProperties,
-    [Parameter(Mandatory = $false)][string]$SpecCustomProperties
+    [Parameter(Mandatory = $false)][string]$SpecCustomProperties,
+    [Parameter(Mandatory = $false)][string[]]$Scope = @()
 )
 
 # Enable Citrix PowerShell Cmdlets
 Add-PSSnapin -Name "Citrix.Host.Admin.V2", "Citrix.MachineCreation.Admin.V2"
 
-$Definition = New-ProvImageDefinition -ImageDefinitionName $DefinitionName -OsType Windows -VDASessionSupport MultiSession
+$NewDefinitionParams = @{
+    ImageDefinitionName = $DefinitionName
+    OsType              = "Windows"
+    VDASessionSupport   = "MultiSession"
+}
+
+# The -Scope parameter requires Citrix DaaS DDC 129 or later. Only pass it when scopes are supplied.
+if ($Scope) {
+    $NewDefinitionParams["Scope"] = $Scope
+}
+
+$Definition = New-ProvImageDefinition @NewDefinitionParams
 
 $Version = New-ProvImageVersion -ImageDefinitionName $Definition.ImageDefinitionName
 

--- a/Azure/Image Management/Readme.md
+++ b/Azure/Image Management/Readme.md
@@ -20,6 +20,27 @@ An Image Definition holds information about:
 New-ProvImageDefinition -ImageDefinitionName "demo" -OsType Windows -VDASessionSupport MultiSession
 ```
 
+### Image Definition Scope
+Requires Citrix DaaS DDC 129 or later.
+
+You can assign administrative scopes to an image definition at creation time using the optional `-Scope` parameter:
+
+```powershell
+New-ProvImageDefinition -ImageDefinitionName "demo" -OsType Windows -VDASessionSupport MultiSession -Scope @("ScopeA", "ScopeB")
+```
+
+Add scopes to an existing image definition:
+
+```powershell
+Add-ProvImageDefinitionScope -ImageDefinitionName "demo" -Scope @("ScopeA")
+```
+
+Remove scopes from an existing image definition:
+
+```powershell
+Remove-ProvImageDefinitionScope -ImageDefinitionName "demo" -Scope @("ScopeA")
+```
+
 ### Image Definition Connection
 Image definition connection is the hypervisor connection which holds master images.
 

--- a/Azure/Image Management/Remove-ImageDefinitionScope.ps1
+++ b/Azure/Image Management/Remove-ImageDefinitionScope.ps1
@@ -1,0 +1,26 @@
+<#
+.SYNOPSIS
+    Removes one or more scopes from an existing image definition.
+.DESCRIPTION
+    Remove-ImageDefinitionScope.ps1 removes the specified scope(s) from an existing image definition.
+    The original version of this script is compatible with Citrix DaaS DDC 129.
+.INPUTS
+    1. DefinitionName: Name(s) of the image definition.
+    2. Scope: One or more scope names to remove from the image definition.
+#>
+
+# /*************************************************************************
+# * Copyright © 2025. Cloud Software Group, Inc. All Rights Reserved.
+# * This file is subject to the license terms contained
+# * in the license file that is distributed with this file.
+# *************************************************************************/
+
+param(
+    [string[]]$DefinitionName,
+    [string[]]$Scope
+)
+
+# Enable Citrix PowerShell Cmdlets
+Add-PSSnapin -Name "Citrix.Host.Admin.V2", "Citrix.MachineCreation.Admin.V2"
+
+Remove-ProvImageDefinitionScope -ImageDefinitionName $DefinitionName -Scope $Scope

--- a/Nutanix Prism Central/Image Management/Add-ImageDefinitionScope.ps1
+++ b/Nutanix Prism Central/Image Management/Add-ImageDefinitionScope.ps1
@@ -1,0 +1,26 @@
+<#
+.SYNOPSIS
+    Adds one or more scopes to an existing image definition.
+.DESCRIPTION
+    Add-ImageDefinitionScope.ps1 adds the specified scope(s) to an existing image definition.
+    The original version of this script is compatible with Citrix DaaS DDC 129.
+.INPUTS
+    1. DefinitionName: Name(s) of the image definition.
+    2. Scope: One or more scope names to add to the image definition.
+#>
+
+# /*************************************************************************
+# * Copyright © 2025. Cloud Software Group, Inc. All Rights Reserved.
+# * This file is subject to the license terms contained
+# * in the license file that is distributed with this file.
+# *************************************************************************/
+
+param(
+    [string[]]$DefinitionName,
+    [string[]]$Scope
+)
+
+# Enable Citrix PowerShell Cmdlets
+Add-PSSnapin -Name "Citrix.Host.Admin.V2", "Citrix.MachineCreation.Admin.V2"
+
+Add-ProvImageDefinitionScope -ImageDefinitionName $DefinitionName -Scope $Scope

--- a/Nutanix Prism Central/Image Management/Create-ImageDefinitionAndVersion.ps1
+++ b/Nutanix Prism Central/Image Management/Create-ImageDefinitionAndVersion.ps1
@@ -15,6 +15,7 @@
     8. ConnCustomProperties: Custom properties for the connection. You need to specify the primary clusterId where the prepared image will be placed on. See Readme.md for how to get and specify the ClusterId in CustomProperties.
     9. SpecCustomProperties: Custom properties for the image version spec.
     10. AdditionalStorageIds: The cluster id where the prepared image will be replicated to. See Readme.md for how to get the ClusterId.
+    11. Scope: One or more administrative scope names to assign to the image definition. Optional; defaults to none.
 #>
 
 # /*************************************************************************
@@ -33,13 +34,25 @@ param(
     [Parameter(Mandatory = $false)][string]$MachineProfile,
     [Parameter(Mandatory = $false)][string]$ConnCustomProperties,
     [Parameter(Mandatory = $false)][string]$SpecCustomProperties,
-    [Parameter(Mandatory = $false)][string]$AdditionalStorageIds
+    [Parameter(Mandatory = $false)][string]$AdditionalStorageIds,
+    [Parameter(Mandatory = $false)][string[]]$Scope = @()
 )
 
 # Enable Citrix PowerShell Cmdlets
 Add-PSSnapin -Name "Citrix.Host.Admin.V2", "Citrix.MachineCreation.Admin.V2"
 
-$Definition = New-ProvImageDefinition -ImageDefinitionName $DefinitionName -OsType Windows -VDASessionSupport MultiSession
+$NewDefinitionParams = @{
+    ImageDefinitionName = $DefinitionName
+    OsType              = "Windows"
+    VDASessionSupport   = "MultiSession"
+}
+
+# The -Scope parameter requires Citrix DaaS DDC 129 or later. Only pass it when scopes are supplied.
+if ($Scope) {
+    $NewDefinitionParams["Scope"] = $Scope
+}
+
+$Definition = New-ProvImageDefinition @NewDefinitionParams
 
 $Version = New-ProvImageVersion -ImageDefinitionName $Definition.ImageDefinitionName
 

--- a/Nutanix Prism Central/Image Management/Readme.md
+++ b/Nutanix Prism Central/Image Management/Readme.md
@@ -38,6 +38,27 @@ An Image Definition holds information about:
 New-ProvImageDefinition -ImageDefinitionName "demo" -OsType Windows -VDASessionSupport MultiSession
 ```
 
+### Image Definition Scope
+Requires Citrix DaaS DDC 129 or later.
+
+You can assign administrative scopes to an image definition at creation time using the optional `-Scope` parameter:
+
+```powershell
+New-ProvImageDefinition -ImageDefinitionName "demo" -OsType Windows -VDASessionSupport MultiSession -Scope @("ScopeA", "ScopeB")
+```
+
+Add scopes to an existing image definition:
+
+```powershell
+Add-ProvImageDefinitionScope -ImageDefinitionName "demo" -Scope @("ScopeA")
+```
+
+Remove scopes from an existing image definition:
+
+```powershell
+Remove-ProvImageDefinitionScope -ImageDefinitionName "demo" -Scope @("ScopeA")
+```
+
 ### Image Definition Connection
 Image definition connection is the hypervisor connection which holds master images.
 

--- a/Nutanix Prism Central/Image Management/Remove-ImageDefinitionScope.ps1
+++ b/Nutanix Prism Central/Image Management/Remove-ImageDefinitionScope.ps1
@@ -1,0 +1,26 @@
+<#
+.SYNOPSIS
+    Removes one or more scopes from an existing image definition.
+.DESCRIPTION
+    Remove-ImageDefinitionScope.ps1 removes the specified scope(s) from an existing image definition.
+    The original version of this script is compatible with Citrix DaaS DDC 129.
+.INPUTS
+    1. DefinitionName: Name(s) of the image definition.
+    2. Scope: One or more scope names to remove from the image definition.
+#>
+
+# /*************************************************************************
+# * Copyright © 2025. Cloud Software Group, Inc. All Rights Reserved.
+# * This file is subject to the license terms contained
+# * in the license file that is distributed with this file.
+# *************************************************************************/
+
+param(
+    [string[]]$DefinitionName,
+    [string[]]$Scope
+)
+
+# Enable Citrix PowerShell Cmdlets
+Add-PSSnapin -Name "Citrix.Host.Admin.V2", "Citrix.MachineCreation.Admin.V2"
+
+Remove-ProvImageDefinitionScope -ImageDefinitionName $DefinitionName -Scope $Scope

--- a/VMware/Image Management/Add-ImageDefinitionScope.ps1
+++ b/VMware/Image Management/Add-ImageDefinitionScope.ps1
@@ -1,0 +1,26 @@
+<#
+.SYNOPSIS
+    Adds one or more scopes to an existing image definition.
+.DESCRIPTION
+    Add-ImageDefinitionScope.ps1 adds the specified scope(s) to an existing image definition.
+    The original version of this script is compatible with Citrix DaaS DDC 129.
+.INPUTS
+    1. DefinitionName: Name(s) of the image definition.
+    2. Scope: One or more scope names to add to the image definition.
+#>
+
+# /*************************************************************************
+# * Copyright © 2025. Cloud Software Group, Inc. All Rights Reserved.
+# * This file is subject to the license terms contained
+# * in the license file that is distributed with this file.
+# *************************************************************************/
+
+param(
+    [string[]]$DefinitionName,
+    [string[]]$Scope
+)
+
+# Enable Citrix PowerShell Cmdlets
+Add-PSSnapin -Name "Citrix.Host.Admin.V2", "Citrix.MachineCreation.Admin.V2"
+
+Add-ProvImageDefinitionScope -ImageDefinitionName $DefinitionName -Scope $Scope

--- a/VMware/Image Management/Create-ImageDefinitionAndVersion.ps1
+++ b/VMware/Image Management/Create-ImageDefinitionAndVersion.ps1
@@ -13,6 +13,7 @@
     6. VMCpuCount: Number of vCPUs.
     7. VMMemoryMB: Memory size in MB.
     8. MachineProfile: The machine profile used.
+    9. Scope: One or more administrative scope names to assign to the image definition. Optional; defaults to none.
 #>
 
 # /*************************************************************************
@@ -29,13 +30,25 @@ param(
     [hashtable]$NetworkMapping,
     [string] $VMCpuCount,
     [string] $VMMemoryMB,
-    [Parameter(Mandatory = $false)][string]$MachineProfile
+    [Parameter(Mandatory = $false)][string]$MachineProfile,
+    [Parameter(Mandatory = $false)][string[]]$Scope = @()
 )
 
 # Enable Citrix PowerShell Cmdlets
 Add-PSSnapin -Name "Citrix.Host.Admin.V2", "Citrix.MachineCreation.Admin.V2"
 
-$Definition = New-ProvImageDefinition -ImageDefinitionName $DefinitionName -OsType Windows -VDASessionSupport MultiSession
+$NewDefinitionParams = @{
+    ImageDefinitionName = $DefinitionName
+    OsType              = "Windows"
+    VDASessionSupport   = "MultiSession"
+}
+
+# The -Scope parameter requires Citrix DaaS DDC 129 or later. Only pass it when scopes are supplied.
+if ($Scope) {
+    $NewDefinitionParams["Scope"] = $Scope
+}
+
+$Definition = New-ProvImageDefinition @NewDefinitionParams
 
 $Version = New-ProvImageVersion -ImageDefinitionName $Definition.ImageDefinitionName
 

--- a/VMware/Image Management/Readme.md
+++ b/VMware/Image Management/Readme.md
@@ -20,6 +20,27 @@ An Image Definition holds information about:
 New-ProvImageDefinition -ImageDefinitionName "demo" -OsType Windows -VDASessionSupport MultiSession
 ```
 
+### Image Definition Scope
+Requires Citrix DaaS DDC 129 or later.
+
+You can assign administrative scopes to an image definition at creation time using the optional `-Scope` parameter:
+
+```powershell
+New-ProvImageDefinition -ImageDefinitionName "demo" -OsType Windows -VDASessionSupport MultiSession -Scope @("ScopeA", "ScopeB")
+```
+
+Add scopes to an existing image definition:
+
+```powershell
+Add-ProvImageDefinitionScope -ImageDefinitionName "demo" -Scope @("ScopeA")
+```
+
+Remove scopes from an existing image definition:
+
+```powershell
+Remove-ProvImageDefinitionScope -ImageDefinitionName "demo" -Scope @("ScopeA")
+```
+
 ### Image Definition Connection
 Image definition connection is the hypervisor connection which holds master images.
 

--- a/VMware/Image Management/Remove-ImageDefinitionScope.ps1
+++ b/VMware/Image Management/Remove-ImageDefinitionScope.ps1
@@ -1,0 +1,26 @@
+<#
+.SYNOPSIS
+    Removes one or more scopes from an existing image definition.
+.DESCRIPTION
+    Remove-ImageDefinitionScope.ps1 removes the specified scope(s) from an existing image definition.
+    The original version of this script is compatible with Citrix DaaS DDC 129.
+.INPUTS
+    1. DefinitionName: Name(s) of the image definition.
+    2. Scope: One or more scope names to remove from the image definition.
+#>
+
+# /*************************************************************************
+# * Copyright © 2025. Cloud Software Group, Inc. All Rights Reserved.
+# * This file is subject to the license terms contained
+# * in the license file that is distributed with this file.
+# *************************************************************************/
+
+param(
+    [string[]]$DefinitionName,
+    [string[]]$Scope
+)
+
+# Enable Citrix PowerShell Cmdlets
+Add-PSSnapin -Name "Citrix.Host.Admin.V2", "Citrix.MachineCreation.Admin.V2"
+
+Remove-ProvImageDefinitionScope -ImageDefinitionName $DefinitionName -Scope $Scope


### PR DESCRIPTION
Add image definition scope support to the Image Management example scripts for Amazon WorkSpaces Core, Azure, Nutanix Prism Central and VMware:

- Create-ImageDefinitionAndVersion.ps1: new optional -Scope parameter, passed to New-ProvImageDefinition only when scopes are supplied.
- Add-ImageDefinitionScope.ps1 (new): demonstrates Add-ProvImageDefinitionScope.
- Remove-ImageDefinitionScope.ps1 (new): demonstrates Remove-ProvImageDefinitionScope.
- README: new "Image Definition Scope" section, requires Citrix DaaS DDC 129 or later.